### PR TITLE
separate formatting into cls

### DIFF
--- a/Main.tex
+++ b/Main.tex
@@ -68,7 +68,7 @@
         6 & Lorem ipsum dolor sit amet, consectetur adipiscing elit.\\
         \hline
     \end{tabular}
-    \caption{Random Table -- Advenures}
+    \caption{Random Table -- Adventures}
 \end{table}
 
 \colbox{

--- a/Main.tex
+++ b/Main.tex
@@ -1,81 +1,9 @@
 % ltex: language=en-US
-\documentclass[a4paper,14pt,twoside]{extarticle} 
-
-\usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
-\usepackage{graphicx}
-\usepackage{lipsum} % For generating dummy text. Remove in your document
-\usepackage{fancyhdr}
-\usepackage{multicol}
-\usepackage{geometry}
-\usepackage{tabularx}
-\usepackage{titlesec}
-\usepackage{enumitem}
-\usepackage{float}
-\usepackage{hyperref}
-\usepackage[table]{xcolor}
-
-\usepackage{pifont}
-\usepackage[nf]{coelacanth}
-\usepackage[T1]{fontenc}
-%% The font package uses mweights.sty which has som issues with the
-%% \normalfont command. The following two lines fixes this issue.
-\let\oldnormalfont\normalfont
-\def\normalfont{\oldnormalfont\mdseries}
-
-
-% Adjust the margins to fit each page on half of an A4 page
-\geometry{
-    paper=a4paper, % Change to letterpaper for US letter
-    inner=2.5cm, % Inner margin
-    outer=1.5cm, % Outer margin
-    top=2cm, % Top margin
-    bottom=2cm, % Bottom margin
-    footskip=0.9cm % Space for the page number
-}
-
-\setlist[itemize]{topsep=0pt,itemsep=0.1cm,partopsep=1ex,parsep=1ex}
-\setlist[itemize]{leftmargin=0.78cm} % you might have to adjust this based on 
-                                     % the chosen symbol
-
-% you can adjust the properties of an individual itemize like this:
-% \begin{itemize}[leftmargin=5.5mm]
-
-% spacings around sections and (sub-)subsections
-\titlespacing*{\section}
-{0pt}{0.4cm}{0.1cm}
-\titlespacing*{\subsection}
-{0pt}{0.2cm}{0.2cm}
-\titlespacing*{\subsubsection}
-{0pt}{8pt}{2pt}
-
-% Prevent breaking mid-word
-\tolerance=1
-\emergencystretch=\maxdimen
-\hyphenpenalty=10000
-\hbadness=10000
-
-% Give tables more padding
-\renewcommand{\arraystretch}{1.3}
-
-% Middle split size
-\setlength{\columnsep}{0.8cm}
-
-% Boxes with darkened background
-\newcommand{\colbox}[1]{ \noindent\colorbox{gray!25}{\parbox{0.93\linewidth}{#1}}\vspace{0.2cm}} 
-\setlength\fboxsep{0.3cm} % Padding
-
-% FOOT & HEAD
-\def\zinetitle{Your Zine Title}
-\pagestyle{fancy}
-\fancyhf{}
-\fancyhead[LE,RO]{\hrulefill \quad \zinetitle \quad \hrulefill}
-\fancyfoot[C]{\hrulefill \quad \textbf{\thepage} \quad \hrulefill}
+\documentclass{zine} 
 
 % TITLE
-\title{\vspace{-3cm} \hrule \vspace{2mm} \textbf{\textit{\zinetitle}} \vspace{2mm} \hrule}
 \author{\textit{Written by YOURNAME}}
-\date{Last edit: \today}
+\renewcommand\zinetitle{Your Zine Title}
 
 \begin{document}
 
@@ -113,11 +41,11 @@
 % see https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Other_symbols for
 % a list of "ding" numbers to get other symbols.
 \begin{itemize}
-    \item[\ding{228}] Lorem ipsum dolor sit amet.
-    \item[\ding{228}] Lorem ipsum dolor sit amet.
-    \item[\ding{228}] Lorem ipsum dolor sit amet.
-    \item[\ding{228}] Lorem ipsum dolor sit amet.
-    \item[\ding{228}] Lorem ipsum dolor sit amet.
+    \item Lorem ipsum dolor sit amet.
+    \item Lorem ipsum dolor sit amet.
+    \item Lorem ipsum dolor sit amet.
+    \item Lorem ipsum dolor sit amet.
+    \item Lorem ipsum dolor sit amet.
 \end{itemize}
 
 \end{multicols*}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ compiling.
 3. Replace the contents with your own.
 5. Compile the `.tex` file.
 
+All the formatting is taken from zine.cls.
+
+## Submodule Usage
+
+To place the style file in another repository, add it as a submodule:
+
+`git submodule add https://github.com/wintermute-cell/osr-zine-template.git`
+
+Then copy over `Main.tex`, while updating the class's full path:
+
+`cp osr-zine-template/Main.tex .`
+
+> \documentclass{osr-zine-template/zine} 
+
 ## Example
 ![example screenshot](./_example/example01.jpg)
 

--- a/zine.cls
+++ b/zine.cls
@@ -1,0 +1,86 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{zine}[A class to produce OSR RPG Zines]
+
+\DeclareOption*{%
+  \PassOptionsToClass{\CurrentOption}{extarticle} 
+}
+
+\ProcessOptions\relax
+
+\LoadClass[a4paper,14pt,twoside]{extarticle}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{graphicx}
+\usepackage{lipsum} % For generating dummy text. Remove in your document
+\usepackage{fancyhdr}
+\usepackage{multicol}
+\usepackage{geometry}
+\usepackage{tabularx}
+\usepackage{titlesec}
+\usepackage{enumitem}
+\usepackage{float}
+\usepackage{hyperref}
+\usepackage[table]{xcolor}
+
+\usepackage{pifont}
+\usepackage[nf]{coelacanth}
+\usepackage[T1]{fontenc}
+%% The font package uses mweights.sty which has som issues with the
+%% \normalfont command. The following two lines fixes this issue.
+\let\oldnormalfont\normalfont
+\def\normalfont{\oldnormalfont\mdseries}
+
+
+% Adjust the margins to fit each page on half of an A4 page
+\geometry{
+    paper=a4paper, % Change to letterpaper for US letter
+    inner=2.5cm, % Inner margin
+    outer=1.5cm, % Outer margin
+    top=2cm, % Top margin
+    bottom=2cm, % Bottom margin
+    footskip=0.9cm % Space for the page number
+}
+
+\setlist[itemize]{topsep=0pt,itemsep=0.1cm,partopsep=1ex,parsep=1ex}
+\setlist[itemize]{leftmargin=0.78cm} % you might have to adjust this based on 
+\setlist[itemize,1]{label=\ding{228}}
+                                     % the chosen symbol
+
+% you can adjust the properties of an individual itemize like this:
+% \begin{itemize}[leftmargin=5.5mm]
+
+% spacings around sections and (sub-)subsections
+\titlespacing*{\section}
+{0pt}{0.4cm}{0.1cm}
+\titlespacing*{\subsection}
+{0pt}{0.2cm}{0.2cm}
+\titlespacing*{\subsubsection}
+{0pt}{8pt}{2pt}
+
+% Prevent breaking mid-word
+\tolerance=1
+\emergencystretch=\maxdimen
+\hyphenpenalty=10000
+\hbadness=10000
+
+% Give tables more padding
+\renewcommand{\arraystretch}{1.3}
+
+% Middle split size
+\setlength{\columnsep}{0.8cm}
+
+% Boxes with darkened background
+\newcommand{\colbox}[1]{ \noindent\colorbox{gray!25}{\parbox{0.93\linewidth}{#1}}\vspace{0.2cm}} 
+\setlength\fboxsep{0.3cm} % Padding
+
+% FOOT & HEAD
+\def\zinetitle{Your Zine Title}
+\pagestyle{fancy}
+\fancyhf{}
+\fancyhead[LE,RO]{\hrulefill \quad \zinetitle \quad \hrulefill}
+\fancyfoot[C]{\hrulefill \quad \textbf{\thepage} \quad \hrulefill}
+
+% Metadata Formatting
+\title{\vspace{-3cm} \hrule \vspace{2mm} \textbf{\textit{\zinetitle}} \vspace{2mm} \hrule}
+\date{Last edit: \today}


### PR DESCRIPTION
All the formatting now lives in a `.cls` file, while `Main.tex` only shows how to use the file.

The output is unaltered.  The separation is just for clarity.